### PR TITLE
fix(anki-connect): make card sides in `UpdateModel` interface optional

### DIFF
--- a/packages/anki-connect/src/model.ts
+++ b/packages/anki-connect/src/model.ts
@@ -26,7 +26,9 @@ export type ModelTemplates = Record<CardName, Omit<CardTemplate, 'Name'>>;
 
 export interface UpdateModel {
   name: ModelName;
-  templates: ModelTemplates;
+  templates: {
+    [key in keyof ModelTemplates]: Partial<ModelTemplates[key]>;
+  };
 }
 
 export type ActionsToPayloadMap = {


### PR DESCRIPTION
Hi,

Im using Autoanki's anki-connect package to update card templates through Anki-Connect's `updateModelTemplates` action, and ran into a problem with the type used for invoking this action.

Currently the [`UpdateModel`](https://github.com/chenlijun99/autoanki/blob/d718815cb4a92a5b8e010ef275c89cf8122477a0/packages/anki-connect/src/model.ts#L27-L30) interface requires both `"Front"` and `"Back"` properties to be specified when invoking this action.
However, [according to Anki-Connect's documentation](https://github.com/FooSoft/anki-connect/blob/master/README.md#updatemodeltemplates), the endpoint also accepts a request with only one or none of the sides specified, and will then only update the given sides.

I fixed this by making each card side optional in `UpdateModel`'s `"templates"` property, with a mapping of [`ModelTemplates`](https://github.com/chenlijun99/autoanki/blob/d718815cb4a92a5b8e010ef275c89cf8122477a0/packages/anki-connect/src/model.ts#L25) properties to a `Partial` type.
