### PR TITLE
feat(anki-connect): add api key argument to invoke function

### DIFF
--- a/packages/anki-connect/src/index.ts
+++ b/packages/anki-connect/src/index.ts
@@ -32,6 +32,19 @@ function getApiOrigin(input?: ApiOrigin): string {
   return 'http://127.0.0.1:8765';
 }
 
+/**
+ * Can be any type that is also a valid json type, but usually a string.
+ *
+ * Must match the value set in the `"apiKey"` property of the Anki-Connect configuration.
+ */
+export type ApiKey =
+  | string
+  | number
+  | boolean
+  | null
+  | { [key: string]: ApiKey }
+  | ApiKey[];
+
 export interface InvokeArgs<
   ActionName extends ActionNames,
   VersionNumber extends 6,
@@ -41,6 +54,7 @@ export interface InvokeArgs<
   version: VersionNumber;
   request: RequestParams;
   origin?: ApiOrigin;
+  key?: ApiKey;
 }
 
 export type InvokeResponse<
@@ -63,11 +77,16 @@ export async function invoke<
   const version = args.version;
   const params = args.request;
   const origin = getApiOrigin(args.origin);
+  const key = args.key;
 
-  const response = await axios.post(
-    origin,
-    JSON.stringify({ action, version, params })
-  );
+  const response = await axios.post(origin, {
+    action,
+    version,
+    params,
+    ...(key !== undefined && {
+      key,
+    }),
+  });
   if (Object.getOwnPropertyNames(response.data).length !== 2) {
     throw new Error('response has an unexpected number of fields');
   }


### PR DESCRIPTION
- Added an optional api key argument to the `invoke` function of the anki-connect package.
This can be used when the `"apiKey"` property is set in the Anki-Connect [config file](https://github.com/FooSoft/anki-connect/blob/5b6fe5766c0e1ee476c78a9de1c085b37d817cd7/plugin/config.json#L2).

- Removed `JSON.Stringify` from `invoke` function when posting, as `axios.post` serializes the payload object to json internally [[1]](https://github.com/axios/axios/blob/d032edda08948f3f613ff34f32af49cad3aa74db/lib/defaults/index.js#L98-L101) [[2]](https://github.com/axios/axios/blob/d032edda08948f3f613ff34f32af49cad3aa74db/lib/defaults/index.js#L25-L35).

---

Some explanation for the type of the API key, which may seem strange:

```typescript
export type ApiKey =
  | string
  | number
  | boolean
  | null
  | { [key: string]: ApiKey }
  | ApiKey[];
```

Apparently, the Anki-Connect addon allows any value that is a valid json value to be used as an api key.
So for example, even a nested object can be used as an api key in the Anki-Connect configuration.

Example partial config.json:
```json
{
    "apiKey": {
        "prop1": {
            "nested": 1234,
            "nested_list": [1,2,3,4]
        }
    }
}
```

As long as the `"key"` property in the body of the request matches the structure and values of the `"apiKey"` property in the config, the request will be authorized.

Example request body:
```json
{
    "key": {
        "prop1": {
            "nested": 1234,
            "nested_list": [1,2,3,4]
        }
    },
    "action": "...",
    "version": 6
}
```

I do think it's a little strange that the api key can be anything other than a string, but since Anki-Connect does allow it to be other types I think the behavior should be reflected by the type of the api key.
